### PR TITLE
fix: throw errors on nonexistent dir or files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ testdata/
 # Environment variables
 .env
 .env.local
+
+terratags

--- a/main.go
+++ b/main.go
@@ -189,6 +189,12 @@ func main() {
 
 	// Print results
 	if !valid {
+		// Check if this is a directory/file error
+		if len(violations) == 1 && violations[0].ResourceType == "error" {
+			logging.Error("Error: %s", violations[0].MissingTags[0])
+			os.Exit(1)
+		}
+
 		logging.Print("\nTag validation issues found:")
 		for _, violation := range violations {
 			logging.Print("Resource %s '%s' is missing required tags: %s",


### PR DESCRIPTION
## Description

* Added directory existence and Terraform file presence validation to prevent processing invalid paths
* Improved error messaging with cleaner output for directory-related issues instead of confusing tag violation messages
* Added terratags binary to .gitignore to exclude build artifacts from version control


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
